### PR TITLE
package dependency cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/free5gc/tlv
+module github.com/omec-project/tlv
 
 go 1.14
 


### PR DESCRIPTION
Referring to opec-project repositories and  module name should have omec-project